### PR TITLE
Fix/book borrow table

### DIFF
--- a/server/prisma/migrations/20241208060906_/migration.sql
+++ b/server/prisma/migrations/20241208060906_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `BookBorrow` MODIFY `borrow_date` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -43,7 +43,7 @@ model BookBorrow {
   userId      Int
   bookId      Int
   status      BookStatus @default(AVAILABLE)
-  borrow_date DateTime
+  borrow_date DateTime   @default(now())
   return_date DateTime?
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt


### PR DESCRIPTION
## 対応内容
BookBorrowテーブルのborrow_dateカラムに、処理した日がデフォルトで入るように修正